### PR TITLE
Support for table translation + removing 100 children limitation

### DIFF
--- a/index.js
+++ b/index.js
@@ -418,7 +418,6 @@ async function createNewPageForTranslation(originalPage) {
     `\nWait a minute! Now translating the following Notion page:\n${url}\n\n(this may take some time) ...`
   );
   const translatedBlocks = await buildTranslatedBlocks(originalPage.id, 0);
-  console.log(`translatedBlocks = ${translatedBlocks.length}`);
   const newPage = await createNewPageForTranslation(originalPage);
   const blocksAppendParams = {
     block_id: newPage.id,
@@ -442,7 +441,6 @@ async function createNewPageForTranslation(originalPage) {
       block_id: newPage.id,
       children: reducedBlocks,
     };
-    console.log(`from ${beginIndex} to ${endIndex}`);
 
     const blocksAddition = await notion.blocks.children.append(blocksAppendParams);
     if (debug) {


### PR DESCRIPTION
This PR improves the project on two concerns:
- it removes the 100 children limitation: this PR suggests to create elements 10 at a time. This could be increased to a higher level, as long as it stays under the 100;
- it helps with the translation of tables; solution is not perfect, as the generated table looses its look, but it now is translated. 

