### PR TITLE
Add Ukrainian (uk) translation support, request throttling, and line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ const supportedFromLangs = [
   "SV", // Swedish
   "TR", // Turkish
   "ZH", // Chinese
+  "UK", // Ukraine
 ];
 
 const supportedToLangs = [
@@ -104,6 +105,7 @@ const supportedToLangs = [
   "SV", // Swedish
   "TR", // Turkish
   "ZH", // Chinese
+  "UK", // Ukraine
 ];
 
 const printableSupportedFromLangs = supportedFromLangs

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const translator = new deepl.Translator(process.env.DEEPL_API_TOKEN);
 async function translateText(richTextArray, from, to) {
   for (const each of richTextArray) {
     if (each.plain_text) {
+	  await new Promise(r => setTimeout(r, 300)); // ← Затримка 300 мс
       const result = await translator.translateText(each.plain_text, from, to);
       each.plain_text = result.text;
       if (each.text) {


### PR DESCRIPTION
1. Ukrainian language support
- Added "UK" to both supportedFromLangs and supportedToLangs
- Allows translating Notion pages to Ukrainian using DeepL API (if supported by the user's plan)

2. Request throttling to avoid DeepL API 429 errors
- Introduced a 300ms delay between translation requests inside translateText() to prevent TooManyRequestsError
This improves reliability when translating large pages or using the Free API tier

3. .gitattributes for consistent line endings
- Added a .gitattributes file with * text=auto eol=lf
- Ensures all files use consistent Unix-style (LF) line endings across platforms
- Prevents unnecessary diffs caused by CRLF ↔ LF mismatch